### PR TITLE
Fix missing package amavisd-new

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,9 @@ class clamav(
     require => Package['clamav-daemon']
   }
   if $amavis {
+    package { 'amavisd-new':
+      ensure  => latest,
+    }
     user {'clamav':
       ensure  => present,
       gid     => 'clamav',


### PR DESCRIPTION
I added a missing package causing the manifest to fail.

``` puppet
package { 'amavisd-new':
  ensure  => latest,
}
```
